### PR TITLE
Use default kappa if none is provided

### DIFF
--- a/SparseNMF/TITAN_Nesterov.m
+++ b/SparseNMF/TITAN_Nesterov.m
@@ -30,7 +30,6 @@ function [W,H,e,t] = TITAN_Nesterov(X,r,sparsity,options,kappa)
 
 cputime0 = tic; 
 [m,n]=size(X);
-kappa_1=kappa-1;
 %% Parameters of NMF algorithm
 if nargin < 4
     options = [];
@@ -61,6 +60,7 @@ if ~isfield(options,'alphaparam')
     options.alphaparam = 0.3; 
 end
 
+kappa_1 = kappa - 1;
 delta=options.delta; % to check when to stop the inner loop 
 alphaparam=options.alphaparam; % to control the number of inner loop.  
 %% Main loop


### PR DESCRIPTION
Thanks for sharing this code!

I had a minor problem running `TITAN_Nesterov`---it looks like the variable `kappa` is being used before it is initialized. This PR fixes that. 