### PR TITLE
Update MovieLens1M_run.m

### DIFF
--- a/MCP/MovieLens1M_run.m
+++ b/MCP/MovieLens1M_run.m
@@ -24,7 +24,7 @@ val = val/std(val);
 idx = randperm(length(val));
 
 train_Idx = idx(1:floor(length(val)*0.7));
-test_Idx = idx(ceil(length(val)*0.3): end);
+test_Idx = setdiff(idx,train_Idx);
 
 clear idx;
 


### PR DESCRIPTION
test_Idx should be the difference between idx and train_Idx. With test_Idx = idx(ceil(length(val)*0.3): end) a part of the test set was in fact trained.